### PR TITLE
Use display-buffer instead of switch-to-buffer

### DIFF
--- a/wikinforg.el
+++ b/wikinforg.el
@@ -107,7 +107,12 @@ If nil, it is ignored."
     (insert entry)
     (run-hooks 'wikinforg-post-insert-hook)
     (wikinforg-mode)
-    (pop-to-buffer (current-buffer))))
+    ;; display the wikinforg buffer according to user's preferences
+	;; (pops up a new window by default)
+    (let ((window (display-buffer (current-buffer))))
+	  ;; select the window (and it's frame if a separate frame is used)
+	  (when (window-live-p window)
+		(select-window window)))))
 
 ;;;; Commands
 ;;;###autoload

--- a/wikinforg.el
+++ b/wikinforg.el
@@ -107,7 +107,7 @@ If nil, it is ignored."
     (insert entry)
     (run-hooks 'wikinforg-post-insert-hook)
     (wikinforg-mode)
-    (switch-to-buffer (current-buffer))))
+    (display-buffer (current-buffer))))
 
 ;;;; Commands
 ;;;###autoload


### PR DESCRIPTION
This small change allows to use the default Emacs mechanism for automatically choosing a suitable window for a wikinforg buffer instead of displaying it in the current window. 

This section of GNU Emacs manual provides more information about this mechanism: https://www.gnu.org/software/emacs/manual/html_node/elisp/Displaying-Buffers.html.